### PR TITLE
Remove the need for username when cloning gitlab group via HTTPS

### DIFF
--- a/.github/scripts/create-native-image-build-config.sh
+++ b/.github/scripts/create-native-image-build-config.sh
@@ -38,7 +38,7 @@ cmd "${native_image_config_dir}/${local_path}" --debug -r gitlab-clone-example "
 
 local_path="${test_clones_dir}/public-with-token-https-with-submodules-verbose"
 say "Asking to clone a public group using a token, via https, with submodules"
-cmd "${native_image_config_dir}/${local_path}" -v -r -c HTTPS -u devex-bot gitlab-clone-example "${local_path}"
+cmd "${native_image_config_dir}/${local_path}" -v -r -c HTTPS gitlab-clone-example "${local_path}"
 
 local_path="${test_clones_dir}/private-without-token-ssh-with-submodules-verbose"
 say "Asking to clone a private group without using a token, via ssh, with submodules"
@@ -46,7 +46,7 @@ GITLAB_TOKEN="" cmd "${native_image_config_dir}/${local_path}" -v -r gitlab-clon
 
 local_path="${test_clones_dir}/public-without-token-https-with-submodules-verbose"
 say "Asking to clone a private group without using a token, via https, with submodules"
-GITLAB_TOKEN="" cmd "${native_image_config_dir}/${local_path}" -v -r -c HTTPS -u devex-bot gitlab-clone-example-private "${local_path}" || true
+GITLAB_TOKEN="" cmd "${native_image_config_dir}/${local_path}" -v -r -c HTTPS gitlab-clone-example-private "${local_path}" || true
 
 local_path="${test_clones_dir}/private-with-token-ssh-with-submodules-very-verbose"
 say "Asking to clone a private group using a token, via ssh, with submodules"
@@ -54,12 +54,12 @@ cmd "${native_image_config_dir}/${local_path}" -x -r gitlab-clone-example-privat
 
 local_path="${test_clones_dir}/public-with-token-https-with-submodules-very-verbose"
 say "Asking to clone a private group using a token, via https, with submodules"
-cmd "${native_image_config_dir}/${local_path}" -x -r -c HTTPS -u devex-bot gitlab-clone-example-private "${local_path}"
+cmd "${native_image_config_dir}/${local_path}" -x -r -c HTTPS gitlab-clone-example-private "${local_path}"
 
 local_path="${test_clones_dir}/public-by-id-with-token-very-verbose"
 say "Asking to clone a public group by id using a token, via https, with submodules"
-cmd "${native_image_config_dir}/${local_path}" -x -m id -r -c HTTPS -u devex-bot 11961707 "${local_path}"
+cmd "${native_image_config_dir}/${local_path}" -x -m id -r -c HTTPS 11961707 "${local_path}"
 
 local_path="${test_clones_dir}/public-sub-group-by-full-path-with-token-very-verbose"
 say "Asking to clone a public subgroup by full path using a token, via https, with submodules"
-cmd "${native_image_config_dir}/${local_path}" -x -m full_path -r -c HTTPS -u devex-bot gitlab-clone-example/sub-group-2/sub-group-3 "${local_path}"
+cmd "${native_image_config_dir}/${local_path}" -x -m full_path -r -c HTTPS gitlab-clone-example/sub-group-2/sub-group-3 "${local_path}"

--- a/.github/scripts/run-native-binary.sh
+++ b/.github/scripts/run-native-binary.sh
@@ -35,7 +35,7 @@ cd -
 
 local_path="https-with-submodules"
 say "Asking to clone group, via https, with submodules"
-build/native-image/application gitlab clone -x -r -c HTTPS -u devex-bot gitlab-clone-example "${local_path}"
+build/native-image/application gitlab clone -x -r -c HTTPS gitlab-clone-example "${local_path}"
 [[ -f "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 cd "${local_path}/gitlab-clone-example/a-project"
 [[ "$(git remote -v | head -n 1)" == *"https://"* ]]
@@ -43,7 +43,7 @@ cd -
 
 local_path="https-by-id"
 say "Asking to clone group by id"
-build/native-image/application gitlab clone -x -r -c HTTPS -u devex-bot -m id 11961707 "${local_path}"
+build/native-image/application gitlab clone -x -r -c HTTPS -m id 11961707 "${local_path}"
 [[ -f "${local_path}/gitlab-clone-example/a-project/some-project-sub-module/README.md" ]]
 cd "${local_path}/gitlab-clone-example/a-project"
 [[ "$(git remote -v | head -n 1)" == *"https://"* ]]

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -62,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       release_body_file: "body.txt"
+    outputs:
+      new_version: ${{ steps.release-files.outputs.new_version }}
+      all_files_sha: ${{ steps.release-files.outputs.all_files_sha }}
     steps:
       - name: "Checkout sources"
         uses: actions/checkout@v2
@@ -87,6 +90,7 @@ jobs:
           for file in *; do sha256sum "${file}" > "${file}.sha256sum"; done
           tar czf all-files-${version}.tar.gz *
           sha256sum all-files-${version}.tar.gz > all-files-${version}.tar.gz.sha256sum
+          all_files_sha="$( cat all-files-${version}.tar.gz.sha256sum )"
           cd ..
 
           # Create release text
@@ -104,6 +108,8 @@ jobs:
           EOF
 
           echo "${change_log}" >> "${release_body_file}"
+          echo "::set-output name=new_version::${version}"
+          echo "::set-output name=all_files_sha::${all_files_sha}"
         env:
           tag_ref: ${{ github.ref }}
           change_log: ${{ steps.changelog.outputs.changelog }}
@@ -116,3 +122,34 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  brew_tap_update:
+    name: "Create brew tap update PR"
+    needs: create_release
+    runs-on: ubuntu-latest
+    env:
+      new_version: ${{needs.create_release.outputs.new_version}}
+      all_files_sha: ${{needs.create_release.outputs.all_files_sha}}
+    steps:
+      - name: "Checkout sources"
+        uses: actions/checkout@v2
+        with:
+          repository: 'miguelaferreira/homebrew-tools'
+      - name: "Update formula"
+        run: scripts/update-formula.sh "Formula/devex-cli.rb" "${{ env.new_version }}" "${{ env.all_files_sha }}"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "Update devex-cli formula to version ${{ env.new_version }}"
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          base: main
+          branch: update-devex-cli-formula
+          delete-branch: true
+          title: '[New tool release] DevEx cli update'
+          body: |
+            This PR
+            - Updates devex-cli formula to version ${{ env.new_version }}
+            - All files package sha is ${{ env.all_files_sha }
+            - Auto-generated from [devex-cli Continuous Delivery workflow][1]
+
+            [1]: https://github.com/miguelaferreira/devex-cli/actions/workflows/create-release.yaml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # devex-cli
 
-Development Experience command line tools.
+Development Experience command line tools. Automating away the development gruntwork.
 
 ## Installing
 
@@ -17,141 +17,9 @@ it executable and place it on a reachable path; or use `brew`.
 brew install miguelaferreira/tools/devex-cli
 ```
 
-## GitLab
+## Documentation
 
-GitLab offers the ability to create groups of repositories and then leverage those groups to manage multiple
-repositories at one. Things like CI/CD, user membership can be defined at the group level and then inherited by all the
-underlying repositories. Furthermore, it's also possible to create relationships between repositories simply by
-leveraging the group structure. For example, one can include git sub-modules and reference them by their relative path.
-
-It's handy, and sometimes needed, to clone the groups of repositories preserving the group structure. That is what this
-tool does.
-
-## Usage
-
-Both the gitlab url (`GITLAB_URL`) and the private token (`GITLAB_TOKEN`) for accessing GitLab API are read from the
-environment. The GitLab url defaults to [https://gitlab.com](https://gitlab.com) when not defined in the environment.
-For cloning public groups no token is needed, for private groups a token with scope `read_api` is required. See
-GitLab's [Limiting scopes of a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)
-for more details on token scopes.
-
-### Public groups
-
-Cloning public groups does not require a gitlab token, however without a token it won't be possible to detect the version of GitLab server.
-That always results in an error message, and in defaulting to using the `group_descendants` API, which is not available in versions of GitLab pre `13.5`.
-
-**Cloning a public group by name, to the current directory, using SSH protocol**
-```bash
-devex gitlab clone open-source-devex
-```
-**Cloning a public group by name, to the current directory, initializing git submodules, using SSH protocol**
-```bash
-devex gitlab clone --recurse-submodules open-source-devex
-```
-**Cloning a group by name, to a specified location, using SSH protocol**
-```bash
-devex gitlab clone open-source-devex ~/some-path-on-my-home
-```
-**Cloning a public group by id, to the current directory, using SSH protocol**
-```bash
-devex gitlab clone --search-mode id 2150497
-```
-**Cloning a public group by path, to the current directory, using SSH protocol**
-```bash
-devex gitlab clone --search-mode full_path open-source-devex/terraform-modules/aws
-```
-**Cloning a public group by name, to the current directory, using HTTPS protocol**
-```bash
-devex gitlab clone --clone-protocol https open-source-devex
-```
-
-### Private groups and self-hosted GitLab servers
-
-Cloning private groups requires a gitlab token.
-Cloning from GitLab servers other than [gitlab.com](https://gitlab.com) requires the url for the server.
-
-**Cloning a private group by name, to the current directory, using SSH protocol**
-```bash
-GITLAB_TOKEN="..." devex gitlab clone "some private group"
-```
-**Cloning a private group by name, to the current directory, using HTTPS protocol**
-```bash
-GITLAB_TOKEN="..." devex gitlab clone --clone-protocol https --https-username miguelaferreira "some private group"
-```
-**Cloning a private group by name, to the current directory, using SSH protocol, from a self-hosted GitLab server**
-```bash
-GITLAB_URL="https://gitlab.acme.com" GITLAB_TOKEN="..." devex gitlab clone "some private group"
-```
-
-### Full usage description
-```
-$ devex gitlab clone -h
-Usage:
-
-Clone an entire GitLab group with all sub-groups and repositories.
-While cloning initialize project git sub-modules (may require two runs due to ordering of projects).
-When a project is already cloned, tries to initialize git sub-modules.
-
-devex gitlab clone [-hrvVx] [--debug] [--trace] [-u[=<httpsUsername>]] [-c=<cloneProtocol>] [-m=<searchMode>] GROUP PATH
-
-GitLab configuration:
-
-The GitLab URL and private token are read from the environment, using GITLAB_URL and GITLAB_TOKEN variables.
-GITLAB_URL defaults to 'https://gitlab.com'.
-The GitLab token is used for both querying the GitLab API and discover the group to clone and as the password for
-cloning using HTTPS.
-No token is needed for public groups and repositories.
-
-Parameters:
-      GROUP                  The GitLab group to clone.
-      PATH                   The local path where to create the group clone.
-
-Options:
-  -h, --help                 Show this help message and exit.
-  -V, --version              Print version information and exit.
-  -r, --recurse-submodules   Initialize project submodules. If projects are already cloned try and initialize
-                               sub-modules anyway.
-  -c, --clone-protocol=<cloneProtocol>
-                             Chose the transport protocol used clone the project repositories. Valid values: SSH, HTTPS.
-  -m, --search-mode=<searchMode>
-                             Chose how the group is searched for. Groups can be searched by name or full path. Valid
-                               values: NAME, FULL_PATH, ID.
-  -u, --https-username[=<httpsUsername>]
-                             The username to authenticate with when the HTTPS clone protocol is selected. This option
-                               is required when cloning private groups, in which case the GitLab token will be used as
-                               the password.
-  -v, --verbose              Print out extra information about what the tool is doing.
-  -x, --very-verbose         Print out even more information about what the tool is doing.
-      --debug                Sets all loggers to DEBUG level.
-      --trace                Sets all loggers to TRACE level. WARNING: this setting will leak the GitLab token or
-                               password to the logs, use with caution.
-
-Copyright(c) 2021 - Miguel Ferreira - GitHub/GitLab: @miguelaferreira
-```
-
-### Protocols
-
-The tool supports both SSH and HTTPS protocols for cloning projects, SSH being the default protocol.
-
-#### SSH
-
-There are three requirements for cloning via SSH that apply to both public and private groups:
-
-1. A known hosts file containing and entry for the GitLab server must exist in the default
-   location (`${HOME}/.ssh/known_hosts`). This entry looks something like
-   this: `gitlab.com,172.65.251.78 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=`
-2. A private key must exist in the default location (`${HOME}/.ssh/id_rsa`) or in a different location as long there is
-   an entry for the GitLab server in the ssh client configuration that points to the correct key.
-   See [GitLab documentation on configuring SSH access](https://docs.gitlab.com/ee/ssh/) for more information on how to
-   set this up
-3. The private key must be in the PEM format, the keyfile needs to start with the line:
-   `-----BEGIN RSA PRIVATE KEY-----`
-   _Note: Support for the OpenSSH key format will be available once a native binary can be produced with a Java15
-   GraalVM native-image. See Issue #16 to track progress of this_
-
-Cloning via HTTPS (cli option `--clone-protocol=HTTPS`) does not require any setup for public groups. For private
-groups, the username needs to be provided (cli option `--https-username=<USERNAME>`). The GitLab token specified on the
-environment will be used as the password for the HTTPS authentication.
+The usage of the tool is documented at https://miguelaferreira.gitbook.io/devex/devex-cli/overview.
 
 ## Development
 

--- a/src/main/java/devex/GitlabCloneCommand.java
+++ b/src/main/java/devex/GitlabCloneCommand.java
@@ -42,7 +42,8 @@ public class GitlabCloneCommand implements Runnable {
             order = 1,
             names = {"-c", "--clone-protocol"},
             description = "Chose the transport protocol used clone the project repositories. Valid values: ${COMPLETION-CANDIDATES}.",
-            defaultValue = "SSH"
+            defaultValue = "SSH",
+            showDefaultValue = CommandLine.Help.Visibility.ALWAYS
     )
     private GitCloneProtocol cloneProtocol;
 
@@ -50,7 +51,8 @@ public class GitlabCloneCommand implements Runnable {
             order = 2,
             names = {"-m", "--search-mode"},
             description = "Chose how the group is searched for. Groups can be searched by name or full path. Valid values: ${COMPLETION-CANDIDATES}.",
-            defaultValue = "NAME"
+            defaultValue = "NAME",
+            showDefaultValue = CommandLine.Help.Visibility.ALWAYS
     )
     private GitlabGroupSearchMode searchMode;
 
@@ -75,7 +77,7 @@ public class GitlabCloneCommand implements Runnable {
             paramLabel = "PATH",
             description = "The local path where to create the group clone.",
             defaultValue = ".",
-            showDefaultValue = CommandLine.Help.Visibility.ON_DEMAND
+            showDefaultValue = CommandLine.Help.Visibility.ALWAYS
     )
     private String localPath;
 

--- a/src/main/java/devex/GitlabCloneCommand.java
+++ b/src/main/java/devex/GitlabCloneCommand.java
@@ -56,15 +56,6 @@ public class GitlabCloneCommand implements Runnable {
     )
     private GitlabGroupSearchMode searchMode;
 
-    @CommandLine.Option(
-            order = 3,
-            names = {"-u", "--https-username"},
-            description = "The username to authenticate with when the HTTPS clone protocol is selected. This option is required when cloning private groups, in which case the GitLab token will be used as the password.",
-            arity = "0..1",
-            interactive = true
-    )
-    private String httpsUsername;
-
     @CommandLine.Parameters(
             index = "0",
             paramLabel = "GROUP",
@@ -94,7 +85,6 @@ public class GitlabCloneCommand implements Runnable {
 
     private void configureGitService() {
         gitService.setCloneProtocol(cloneProtocol);
-        gitService.setHttpsUsername(httpsUsername);
     }
 
     private void cloneGroup() {

--- a/src/main/java/devex/git/GitService.java
+++ b/src/main/java/devex/git/GitService.java
@@ -23,18 +23,14 @@ import java.util.Objects;
 public class GitService {
 
     private static final SshSessionFactory sshSessionFactory = new OverrideJschConfigSessionFactory();
+    public static final String HTTPS_USERNAME = "git";
 
     private GitCloneProtocol cloneProtocol = GitCloneProtocol.SSH;
-    private String httpsUsername = "";
     @Value("${gitlab.token:}")
     private String httpsPassword = "";
 
     public void setCloneProtocol(GitCloneProtocol cloneProtocol) {
         this.cloneProtocol = cloneProtocol;
-    }
-
-    public void setHttpsUsername(String httpsUsername) {
-        this.httpsUsername = httpsUsername;
     }
 
     protected void setHttpsPassword(String httpsPassword) {
@@ -95,10 +91,9 @@ public class GitService {
                 break;
             case HTTPS:
                 cloneCommand.setURI(project.getHttpUrlToRepo());
-                final String username = Objects.requireNonNullElse(httpsUsername, "");
                 final String password = Objects.requireNonNullElse(httpsPassword, "");
-                if (!username.isBlank() && !password.isBlank()) {
-                    cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(httpsUsername, httpsPassword));
+                if (!password.isBlank()) {
+                    cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(HTTPS_USERNAME, httpsPassword));
                 } else {
                     log.debug("Credentials for HTTPS remote not set, group to clone must be public.");
                 }

--- a/src/test/java/devex/git/GitServiceTest.java
+++ b/src/test/java/devex/git/GitServiceTest.java
@@ -23,8 +23,6 @@ import static org.eclipse.jgit.submodule.SubmoduleStatusType.UNINITIALIZED;
 
 class GitServiceTest extends TestBase {
 
-    public static final String GITLAB_BOT_USERNAME = "devex-bot";
-
     @TempDir
     File cloneDirectory;
     private String cloneDirectoryPath;
@@ -87,7 +85,6 @@ class GitServiceTest extends TestBase {
     void clonePrivateRepo_http_withSubmodule() throws GitAPIException {
         final GitService gitService = new GitService();
         gitService.setCloneProtocol(GitCloneProtocol.HTTPS);
-        gitService.setHttpsUsername(GITLAB_BOT_USERNAME);
         gitService.setHttpsPassword(gitlabBotPassword);
         final GitlabProject project = GitlabProject.builder()
                                                    .name("a-private-project")


### PR DESCRIPTION
This PR removes the username parameter from the `devex gitlab clone` command when cloning via HTTPS. This PR also updates the README.md with a link to the GitBook documentation.