### PR TITLE
Upgrade jackson databind

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -170,8 +170,8 @@ jobs:
           body: |
             This PR
             - Updates devex-cli formulas to version ${{ env.new_version }}
-            - Source archive sha is ${{ steps.update-formula.outputs.archive-sha }}
-            - All files package sha is ${{ env.all_files_sha }}
+            - Source archive sha is `${{ steps.update-formula.outputs.archive-sha }}`
+            - All files package sha is `${{ env.all_files_sha }}`
             - Auto-generated from [devex-cli Continuous Delivery workflow][1] ([workflow src][2])
 
             [1]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,16 @@ dependencies {
 
     annotationProcessor("info.picocli:picocli-codegen")
     implementation("info.picocli:picocli")
-    implementation("io.micronaut:micronaut-http-client")
-    implementation("io.micronaut:micronaut-runtime")
-    implementation("io.micronaut.picocli:micronaut-picocli")
+    implementation("io.micronaut:micronaut-http-client") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
+    implementation("io.micronaut:micronaut-runtime") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
+    implementation("io.micronaut.picocli:micronaut-picocli") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
+
     implementation("io.micronaut:micronaut-validation")
 
     // patch vulnerable jackson dependency
@@ -44,7 +51,9 @@ dependencies {
 
 
     implementation 'io.vavr:vavr:0.10.3'
-    implementation("io.vavr:vavr-jackson:0.10.3")
+    implementation("io.vavr:vavr-jackson:0.10.3") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
 
     implementation 'org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r'
     implementation('org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:5.11.0.202103091610-r') {


### PR DESCRIPTION
This PR excludes vulnerable version of Jackson DataBind dependency.