### PR TITLE
Improve logging when repository has already been cloned

### DIFF
--- a/src/main/java/devex/GithubCloneCommand.java
+++ b/src/main/java/devex/GithubCloneCommand.java
@@ -2,6 +2,7 @@ package devex;
 
 
 import devex.git.GitCloneProtocol;
+import devex.git.GitCloneResults;
 import devex.git.GitRepository;
 import devex.git.GitService;
 import devex.github.GithubOrganization;
@@ -110,11 +111,8 @@ public class GithubCloneCommand implements Runnable {
                           .forEach(tuple -> {
                               final GithubRepository repository = tuple._1;
                               final Either<Throwable, Git> gitRepoOrError = tuple._2;
-                              if (gitRepoOrError.isLeft()) {
-                                  log.warn("Git operation failed", gitRepoOrError.getLeft());
-                              } else {
-                                  log.info("Repository '{}' updated.", repository.getFullName());
-                              }
+                              GitCloneResults.log(log, gitRepoOrError,
+                                      () -> String.format("Repository '%s' updated.", repository.getFullName()));
                           });
 
         log.info("All done.");

--- a/src/main/java/devex/GitlabCloneCommand.java
+++ b/src/main/java/devex/GitlabCloneCommand.java
@@ -1,6 +1,7 @@
 package devex;
 
 import devex.git.GitCloneProtocol;
+import devex.git.GitCloneResults;
 import devex.git.GitRepository;
 import devex.git.GitService;
 import devex.gitlab.GitlabGroup;
@@ -119,11 +120,8 @@ public class GitlabCloneCommand implements Runnable {
                       .forEach(tuple -> {
                           final GitlabProject project = tuple._1;
                           final Either<Throwable, Git> gitRepoOrError = tuple._2;
-                          if (gitRepoOrError.isLeft()) {
-                              log.warn("Git operation failed", gitRepoOrError.getLeft());
-                          } else {
-                              log.info("Project '{}' updated.", project.getNameWithNamespace());
-                          }
+                          GitCloneResults.log(log, gitRepoOrError,
+                                  () -> String.format("Project '%s' updated.", project.getNameWithNamespace()));
                       });
 
         log.info("All done.");

--- a/src/main/java/devex/git/GitCloneResults.java
+++ b/src/main/java/devex/git/GitCloneResults.java
@@ -1,0 +1,37 @@
+package devex.git;
+
+import io.vavr.control.Either;
+import org.eclipse.jgit.api.Git;
+import org.slf4j.Logger;
+
+import java.util.function.Supplier;
+
+/**
+ * Logs the outcome of a clone operation consistently across clone commands.
+ */
+public final class GitCloneResults {
+
+    private GitCloneResults() {
+    }
+
+    /**
+     * Logs the result of a clone using the caller's logger so the log line keeps
+     * the calling command's logger name.
+     *
+     * @param log            the caller's logger
+     * @param result         the clone result; a right holds the cloned repository, a left the failure cause
+     * @param successMessage supplies the message logged at INFO when the clone succeeded
+     */
+    public static void log(final Logger log, final Either<Throwable, Git> result, final Supplier<String> successMessage) {
+        if (result.isRight()) {
+            log.info(successMessage.get());
+            return;
+        }
+        final Throwable error = result.getLeft();
+        if (error instanceof RepositoryAlreadyClonedException) {
+            log.info(error.getMessage());
+        } else {
+            log.warn("Git operation failed", error);
+        }
+    }
+}

--- a/src/main/java/devex/git/GitService.java
+++ b/src/main/java/devex/git/GitService.java
@@ -190,8 +190,22 @@ public class GitService {
     public Either<Throwable, Git> clone(final GitRepository repository, final String cloneDirectory) {
         final String repositoryName = repository.getName();
         log.trace("Cloning repository '{}' under directory '{}'", repositoryName, cloneDirectory);
+        if (isAlreadyCloned(repository, cloneDirectory)) {
+            return Either.left(new RepositoryAlreadyClonedException(repositoryName));
+        }
         return tryClone(repository, cloneDirectory, false)
                 .toEither();
+    }
+
+    private boolean isAlreadyCloned(final GitRepository repository, final String cloneDirectory) {
+        final String pathToRepo = cloneDirectory + FileSystems.getDefault().getSeparator() + repository.getPath();
+        final File repositoryDirectory = new File(pathToRepo);
+        if (!repositoryDirectory.isDirectory()) {
+            return false;
+        }
+        return Try.withResources(() -> Git.open(repositoryDirectory))
+                  .of(git -> true)
+                  .getOrElse(false);
     }
 
     private Try<Git> tryClone(final GitRepository repository, final String cloneDirectory, final boolean cloneSubmodules) {

--- a/src/main/java/devex/git/RepositoryAlreadyClonedException.java
+++ b/src/main/java/devex/git/RepositoryAlreadyClonedException.java
@@ -1,0 +1,13 @@
+package devex.git;
+
+/**
+ * Signals that a repository was not cloned because a clone already exists at the
+ * target location. This is an expected, benign outcome (not a failure) and lets
+ * callers report it with an informational message rather than a warning.
+ */
+public class RepositoryAlreadyClonedException extends Exception {
+
+    public RepositoryAlreadyClonedException(String repositoryName) {
+        super(String.format("Repository '%s' is already cloned", repositoryName));
+    }
+}

--- a/src/test/java/devex/git/GitCloneResultsTest.java
+++ b/src/test/java/devex/git/GitCloneResultsTest.java
@@ -1,0 +1,75 @@
+package devex.git;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.vavr.control.Either;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitCloneResultsTest {
+
+    private static final String REPOSITORY_NAME = "some-group / a-project";
+    private static final String SUCCESS_MESSAGE = "Repository 'some-group/a-project' updated.";
+    private static final String GENERIC_FAILURE_MESSAGE = "Git operation failed";
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(GitCloneResultsTest.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @BeforeEach
+    void setUp() {
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    @Test
+    void log_repositoryAlreadyCloned_logsInfoSayingAlreadyCloned() {
+        final Either<Throwable, Git> result = Either.left(new RepositoryAlreadyClonedException(REPOSITORY_NAME));
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                                     assertThat(event.getFormattedMessage()).contains(REPOSITORY_NAME)
+                                                                            .contains("already cloned");
+                                 });
+    }
+
+    @Test
+    void log_genericFailure_logsWarnGitOperationFailed() {
+        final Either<Throwable, Git> result = Either.left(new IllegalStateException("boom"));
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                                     assertThat(event.getFormattedMessage()).isEqualTo(GENERIC_FAILURE_MESSAGE);
+                                 });
+    }
+
+    @Test
+    void log_success_logsInfoWithSuccessMessage() {
+        final Either<Throwable, Git> result = Either.right(null);
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                                     assertThat(event.getFormattedMessage()).isEqualTo(SUCCESS_MESSAGE);
+                                 });
+    }
+}

--- a/src/test/java/devex/git/GitServiceTest.java
+++ b/src/test/java/devex/git/GitServiceTest.java
@@ -24,6 +24,11 @@ import static org.eclipse.jgit.submodule.SubmoduleStatusType.UNINITIALIZED;
 
 class GitServiceTest extends TestBase {
 
+    private static final String REPOSITORY_NAME = "some-group / a-project";
+    private static final String REPOSITORY_PATH = "some-group/a-project";
+    private static final String REPOSITORY_SSH_URL = "git@example.com:some-group/a-project.git";
+    private static final String REPOSITORY_HTTPS_URL = "https://example.invalid/some-group/a-project.git";
+
     @TempDir
     File cloneDirectory;
     private String cloneDirectoryPath;
@@ -245,6 +250,43 @@ class GitServiceTest extends TestBase {
         assertThat(errors).isEmpty();
         assertThat(gits).hasSize(3);
         assertThat(submoduleStatus).allSatisfy(subModules -> assertThat(subModules).allSatisfy(this::submoduleIsInitialized));
+    }
+
+    @Test
+    void clone_repositoryAlreadyCloned_returnsRepositoryAlreadyClonedException() throws GitAPIException {
+        final GitRepository repository = anExampleRepository();
+        final File existingRepoDirectory = new File(cloneDirectoryPath, REPOSITORY_PATH);
+        Git.init().setDirectory(existingRepoDirectory).call().close();
+
+        final Either<Throwable, Git> result = new GitService().clone(repository, cloneDirectoryPath);
+
+        assertThat(result.isLeft()).as("clone of an already-cloned repository returns a Left").isTrue();
+        assertThat(result.getLeft()).isInstanceOf(RepositoryAlreadyClonedException.class)
+                                    .hasMessageContaining(REPOSITORY_NAME)
+                                    .hasMessageContaining("already cloned");
+    }
+
+    @Test
+    void clone_directoryIsNotARepository_isNotTreatedAsAlreadyCloned() {
+        final GitService gitService = new GitService();
+        gitService.setCloneProtocol(GitCloneProtocol.HTTPS);
+        final GitRepository repository = anExampleRepository();
+        final File notARepositoryDirectory = new File(cloneDirectoryPath, REPOSITORY_PATH);
+        assertThat(notARepositoryDirectory.mkdirs()).as("the target directory exists but is not a git repository").isTrue();
+
+        final Either<Throwable, Git> result = gitService.clone(repository, cloneDirectoryPath);
+
+        assertThat(result.isLeft()).as("cloning into a non-repository directory still attempts (and fails) the clone").isTrue();
+        assertThat(result.getLeft()).isNotInstanceOf(RepositoryAlreadyClonedException.class);
+    }
+
+    private GitRepository anExampleRepository() {
+        return GitRepository.builder()
+                            .name(REPOSITORY_NAME)
+                            .path(REPOSITORY_PATH)
+                            .cloneUrlSsh(REPOSITORY_SSH_URL)
+                            .cloneUrlHttps(REPOSITORY_HTTPS_URL)
+                            .build();
     }
 
     private <T> Stream<T> flowableToStream(Flux<T> gits) {


### PR DESCRIPTION
Print a info message saying a repository has already been cloned, instead of a warning for failed git operation.