### PR TITLE
Support cloning gh user repos

### DIFF
--- a/src/main/java/devex/GithubCloneCommand.java
+++ b/src/main/java/devex/GithubCloneCommand.java
@@ -2,6 +2,7 @@ package devex;
 
 
 import devex.git.GitCloneProtocol;
+import devex.git.GitCloneResults;
 import devex.git.GitRepository;
 import devex.git.GitService;
 import devex.github.GithubOrganization;
@@ -110,11 +111,8 @@ public class GithubCloneCommand implements Runnable {
                           .forEach(tuple -> {
                               final GithubRepository repository = tuple._1;
                               final Either<Throwable, Git> gitRepoOrError = tuple._2;
-                              if (gitRepoOrError.isLeft()) {
-                                  log.warn("Git operation failed", gitRepoOrError.getLeft());
-                              } else {
-                                  log.info("Repository '{}' updated.", repository.getFullName());
-                              }
+                              GitCloneResults.log(log, gitRepoOrError,
+                                      () -> String.format("Repository '%s' updated.", repository.getFullName()));
                           });
 
         log.info("All done.");

--- a/src/main/java/devex/GithubCloneCommand.java
+++ b/src/main/java/devex/GithubCloneCommand.java
@@ -26,6 +26,7 @@ import jakarta.inject.Inject;
         aliases = "cl",
         header = {
                 "Clone an entire GitHub organization with all repositories.",
+                "When no organization matches the given name, clone all repositories of the GitHub user with that name instead.",
                 "While cloning, initialize project git sub-modules if option@|bold,underline -r|@ is provided.",
                 "When a project is already cloned, tries to initialize git sub-modules if options@|bold,underline -r|@ is provided."
         }
@@ -52,14 +53,14 @@ public class GithubCloneCommand implements Runnable {
     @CommandLine.Parameters(
             index = "0",
             paramLabel = "ORG",
-            description = "The GitHub organization to clone."
+            description = "The GitHub organization to clone. If no organization matches, it is treated as a GitHub user."
     )
     private String githubOrg;
 
     @CommandLine.Parameters(
             index = "1",
             paramLabel = "PATH",
-            description = "The local path where to create the organization clone.",
+            description = "The local path where to create the organization (or user) clone.",
             defaultValue = ".",
             showDefaultValue = CommandLine.Help.Visibility.ALWAYS
     )
@@ -86,19 +87,16 @@ public class GithubCloneCommand implements Runnable {
     }
 
     private void cloneGroup() {
-        log.info("Cloning organization '{}'", githubOrg);
+        log.info("Cloning '{}'", githubOrg);
 
-        final Either<String, GithubOrganization> maybeOrganization = githubService.getOrganization(githubOrg);
-        if (maybeOrganization.isLeft()) {
-            log.info("Could not find organization '{}': {}", githubOrg, maybeOrganization.getLeft());
+        final Either<String, Flux<GithubRepository>> maybeRepositories = resolveRepositories();
+        if (maybeRepositories.isLeft()) {
+            log.info("Could not find organization or user '{}': {}", githubOrg, maybeRepositories.getLeft());
             return;
         }
 
-        final GithubOrganization organization = maybeOrganization.get();
-        log.debug("Found organization = {}", organization);
-
         final Flux<Tuple2<GithubRepository, Either<Throwable, Git>>> clonedRepositories =
-                githubService.getOrganizationRepositories(organization.getName())
+                maybeRepositories.get()
                              .map(repository -> Tuple.of(repository, buildGitRepository(repository)))
                              .map(tuple -> tuple.map2(
                                              repository -> recurseSubmodules
@@ -116,6 +114,25 @@ public class GithubCloneCommand implements Runnable {
                           });
 
         log.info("All done.");
+    }
+
+    private Either<String, Flux<GithubRepository>> resolveRepositories() {
+        final Either<String, GithubOrganization> maybeOrganization = githubService.getOrganization(githubOrg);
+        if (maybeOrganization.isRight()) {
+            final GithubOrganization organization = maybeOrganization.get();
+            log.debug("Found organization = {}", organization);
+            return Either.right(githubService.getOrganizationRepositories(organization.getName()));
+        }
+
+        log.debug("Organization '{}' not found ({}), trying user", githubOrg, maybeOrganization.getLeft());
+        final Either<String, GithubOrganization> maybeUser = githubService.getUser(githubOrg);
+        if (maybeUser.isRight()) {
+            final GithubOrganization user = maybeUser.get();
+            log.debug("Found user = {}", user);
+            return Either.right(githubService.getUserRepositories(user.getName()));
+        }
+
+        return Either.left(maybeUser.getLeft());
     }
 
     private GitRepository buildGitRepository(GithubRepository repository) {

--- a/src/main/java/devex/GithubCommand.java
+++ b/src/main/java/devex/GithubCommand.java
@@ -14,8 +14,8 @@ import picocli.CommandLine.Command;
         description = {
                 "The GitHub URL and private token are read from the environment, using GItHUB_URL and GITHUB_TOKEN variables.",
                 "GItHUB_URL defaults to 'https://api.github.com'.",
-                "The GitHub token is used for both querying the GitHub API to discover the organization to clone and as the password for cloning using HTTPS.",
-                "No token is needed for public groups and repositories."
+                "The GitHub token is used for both querying the GitHub API to discover the organization (or user) to clone and as the password for cloning using HTTPS.",
+                "No token is needed for public organizations, users and repositories."
         },
         scope = CommandLine.ScopeType.INHERIT
 )

--- a/src/main/java/devex/GitlabCloneCommand.java
+++ b/src/main/java/devex/GitlabCloneCommand.java
@@ -1,6 +1,7 @@
 package devex;
 
 import devex.git.GitCloneProtocol;
+import devex.git.GitCloneResults;
 import devex.git.GitRepository;
 import devex.git.GitService;
 import devex.gitlab.GitlabGroup;
@@ -119,11 +120,8 @@ public class GitlabCloneCommand implements Runnable {
                       .forEach(tuple -> {
                           final GitlabProject project = tuple._1;
                           final Either<Throwable, Git> gitRepoOrError = tuple._2;
-                          if (gitRepoOrError.isLeft()) {
-                              log.warn("Git operation failed", gitRepoOrError.getLeft());
-                          } else {
-                              log.info("Project '{}' updated.", project.getNameWithNamespace());
-                          }
+                          GitCloneResults.log(log, gitRepoOrError,
+                                  () -> String.format("Project '%s' updated.", project.getNameWithNamespace()));
                       });
 
         log.info("All done.");

--- a/src/main/java/devex/git/GitCloneResults.java
+++ b/src/main/java/devex/git/GitCloneResults.java
@@ -1,0 +1,37 @@
+package devex.git;
+
+import io.vavr.control.Either;
+import org.eclipse.jgit.api.Git;
+import org.slf4j.Logger;
+
+import java.util.function.Supplier;
+
+/**
+ * Logs the outcome of a clone operation consistently across clone commands.
+ */
+public final class GitCloneResults {
+
+    private GitCloneResults() {
+    }
+
+    /**
+     * Logs the result of a clone using the caller's logger so the log line keeps
+     * the calling command's logger name.
+     *
+     * @param log            the caller's logger
+     * @param result         the clone result; a right holds the cloned repository, a left the failure cause
+     * @param successMessage supplies the message logged at INFO when the clone succeeded
+     */
+    public static void log(final Logger log, final Either<Throwable, Git> result, final Supplier<String> successMessage) {
+        if (result.isRight()) {
+            log.info(successMessage.get());
+            return;
+        }
+        final Throwable error = result.getLeft();
+        if (error instanceof RepositoryAlreadyClonedException) {
+            log.info(error.getMessage());
+        } else {
+            log.warn("Git operation failed", error);
+        }
+    }
+}

--- a/src/main/java/devex/git/GitService.java
+++ b/src/main/java/devex/git/GitService.java
@@ -190,8 +190,22 @@ public class GitService {
     public Either<Throwable, Git> clone(final GitRepository repository, final String cloneDirectory) {
         final String repositoryName = repository.getName();
         log.trace("Cloning repository '{}' under directory '{}'", repositoryName, cloneDirectory);
+        if (isAlreadyCloned(repository, cloneDirectory)) {
+            return Either.left(new RepositoryAlreadyClonedException(repositoryName));
+        }
         return tryClone(repository, cloneDirectory, false)
                 .toEither();
+    }
+
+    private boolean isAlreadyCloned(final GitRepository repository, final String cloneDirectory) {
+        final String pathToRepo = cloneDirectory + FileSystems.getDefault().getSeparator() + repository.getPath();
+        final File repositoryDirectory = new File(pathToRepo);
+        if (!repositoryDirectory.isDirectory()) {
+            return false;
+        }
+        return Try.withResources(() -> Git.open(repositoryDirectory))
+                  .of(git -> true)
+                  .getOrElse(false);
     }
 
     private Try<Git> tryClone(final GitRepository repository, final String cloneDirectory, final boolean cloneSubmodules) {

--- a/src/main/java/devex/git/RepositoryAlreadyClonedException.java
+++ b/src/main/java/devex/git/RepositoryAlreadyClonedException.java
@@ -1,0 +1,13 @@
+package devex.git;
+
+/**
+ * Signals that a repository was not cloned because a clone already exists at the
+ * target location. This is an expected, benign outcome (not a failure) and lets
+ * callers report it with an informational message rather than a warning.
+ */
+public class RepositoryAlreadyClonedException extends Exception {
+
+    public RepositoryAlreadyClonedException(String repositoryName) {
+        super(String.format("Repository '%s' is already cloned", repositoryName));
+    }
+}

--- a/src/main/java/devex/github/GithubClient.java
+++ b/src/main/java/devex/github/GithubClient.java
@@ -25,4 +25,10 @@ public interface GithubClient {
 
     @Get(value = "/orgs/{org}/repos{?page}")
     Flux<HttpResponse<List<GithubRepository>>> getOrganizationRepositories(@PathVariable String org, @QueryValue int page);
+
+    @Get(value = "/users/{user}")
+    Optional<GithubOrganization> getUser(@PathVariable String user);
+
+    @Get(value = "/users/{user}/repos{?page}")
+    Flux<HttpResponse<List<GithubRepository>>> getUserRepositories(@PathVariable String user, @QueryValue int page);
 }

--- a/src/main/java/devex/github/GithubService.java
+++ b/src/main/java/devex/github/GithubService.java
@@ -1,6 +1,7 @@
 package devex.github;
 
 import devex.http.HttpClientUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -14,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import jakarta.inject.Singleton;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 @Slf4j
 @Singleton
@@ -27,15 +30,24 @@ public class GithubService {
     }
 
     public Either<String, GithubOrganization> getOrganization(String organization) {
-        log.debug("Getting organization {}", organization);
+        return getAccount("organization", organization, () -> client.getOrganization(organization));
+    }
+
+    public Either<String, GithubOrganization> getUser(String user) {
+        return getAccount("user", user, () -> client.getUser(user));
+    }
+
+    private Either<String, GithubOrganization> getAccount(String accountType, String accountName, Supplier<Optional<GithubOrganization>> fetchAccount) {
+        log.debug("Getting {} {}", accountType, accountName);
         try {
-            return Option.ofOptional(client.getOrganization(organization))
-                         .toEither("Organization not found");
+            return Option.ofOptional(fetchAccount.get())
+                         .toEither(StringUtils.capitalize(accountType) + " not found");
         } catch (HttpClientResponseException e) {
             final HttpStatus status = e.getStatus();
-            log.warn("Unexpected status {} fetching GitHub organization {}: {}, ",
+            log.warn("Unexpected status {} fetching GitHub {} {}: {}, ",
                     status.getCode(),
-                    organization, status.getReason());
+                    accountType,
+                    accountName, status.getReason());
             return Either.left(e.getMessage());
         }
     }
@@ -43,6 +55,11 @@ public class GithubService {
     public Flux<GithubRepository> getOrganizationRepositories(String organization) {
         log.debug("Getting repositories of organization {}", organization);
         return HttpClientUtils.paginatedApiCall(pageIndex -> client.getOrganizationRepositories(organization, pageIndex), this::extractNextPageFromLinkHeader);
+    }
+
+    public Flux<GithubRepository> getUserRepositories(String user) {
+        log.debug("Getting repositories of user {}", user);
+        return HttpClientUtils.paginatedApiCall(pageIndex -> client.getUserRepositories(user, pageIndex), this::extractNextPageFromLinkHeader);
     }
 
     private String extractNextPageFromLinkHeader(HttpResponse<?> response) {

--- a/src/test/java/devex/GithubCloneCommandTest.java
+++ b/src/test/java/devex/GithubCloneCommandTest.java
@@ -1,0 +1,54 @@
+package devex;
+
+import ch.qos.logback.core.joran.spi.JoranException;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("ssh-integration")
+@EnabledIfEnvironmentVariable(named = "DEVEX_SSH_INTEGRATION_TESTS", matches = "true",
+        disabledReason = "Clone tests hit the network; set DEVEX_SSH_INTEGRATION_TESTS=true to run.")
+public class GithubCloneCommandTest extends TestBase {
+
+    private static final String USER = "octocat";
+    private static final int TEST_OUTPUT_ARRAY_SIZE = 4096000;
+
+    @TempDir
+    File cloneDirectory;
+
+    @BeforeAll
+    static void beforeAll() throws JoranException {
+        // Configuration is static and loaded once per JVM; reset it so a full-logs
+        // test running earlier does not leave the full log configuration active.
+        LoggingConfiguration.loadLogsConfig();
+    }
+
+    @Test
+    public void run_userName_clonesUserRepositoriesAsOrganization() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(TEST_OUTPUT_ARRAY_SIZE);
+        System.setOut(new PrintStream(baos));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            String[] args = new String[]{"github", "clone", "-v", "-c", "HTTPS", USER, cloneDirectory.toPath().toString()};
+            DevexCommand.execute(ctx, args);
+
+            final String output = baos.toString();
+            assertThat(output).contains(String.format("Cloning '%s'", USER))
+                              .contains(String.format("Organization '%s' not found", USER))
+                              .contains("Found user")
+                              .contains("All done");
+            assertThat(cloneDirectory).isDirectoryRecursivelyContaining(
+                    String.format("glob:**/%s/Hello-World/README", USER));
+        }
+    }
+}

--- a/src/test/java/devex/git/GitCloneResultsTest.java
+++ b/src/test/java/devex/git/GitCloneResultsTest.java
@@ -1,0 +1,75 @@
+package devex.git;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.vavr.control.Either;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitCloneResultsTest {
+
+    private static final String REPOSITORY_NAME = "some-group / a-project";
+    private static final String SUCCESS_MESSAGE = "Repository 'some-group/a-project' updated.";
+    private static final String GENERIC_FAILURE_MESSAGE = "Git operation failed";
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(GitCloneResultsTest.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @BeforeEach
+    void setUp() {
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    @Test
+    void log_repositoryAlreadyCloned_logsInfoSayingAlreadyCloned() {
+        final Either<Throwable, Git> result = Either.left(new RepositoryAlreadyClonedException(REPOSITORY_NAME));
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                                     assertThat(event.getFormattedMessage()).contains(REPOSITORY_NAME)
+                                                                            .contains("already cloned");
+                                 });
+    }
+
+    @Test
+    void log_genericFailure_logsWarnGitOperationFailed() {
+        final Either<Throwable, Git> result = Either.left(new IllegalStateException("boom"));
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                                     assertThat(event.getFormattedMessage()).isEqualTo(GENERIC_FAILURE_MESSAGE);
+                                 });
+    }
+
+    @Test
+    void log_success_logsInfoWithSuccessMessage() {
+        final Either<Throwable, Git> result = Either.right(null);
+
+        GitCloneResults.log(logger, result, () -> SUCCESS_MESSAGE);
+
+        assertThat(appender.list).singleElement()
+                                 .satisfies(event -> {
+                                     assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                                     assertThat(event.getFormattedMessage()).isEqualTo(SUCCESS_MESSAGE);
+                                 });
+    }
+}

--- a/src/test/java/devex/git/GitServiceTest.java
+++ b/src/test/java/devex/git/GitServiceTest.java
@@ -24,6 +24,11 @@ import static org.eclipse.jgit.submodule.SubmoduleStatusType.UNINITIALIZED;
 
 class GitServiceTest extends TestBase {
 
+    private static final String REPOSITORY_NAME = "some-group / a-project";
+    private static final String REPOSITORY_PATH = "some-group/a-project";
+    private static final String REPOSITORY_SSH_URL = "git@example.com:some-group/a-project.git";
+    private static final String REPOSITORY_HTTPS_URL = "https://example.invalid/some-group/a-project.git";
+
     @TempDir
     File cloneDirectory;
     private String cloneDirectoryPath;
@@ -245,6 +250,43 @@ class GitServiceTest extends TestBase {
         assertThat(errors).isEmpty();
         assertThat(gits).hasSize(3);
         assertThat(submoduleStatus).allSatisfy(subModules -> assertThat(subModules).allSatisfy(this::submoduleIsInitialized));
+    }
+
+    @Test
+    void clone_repositoryAlreadyCloned_returnsRepositoryAlreadyClonedException() throws GitAPIException {
+        final GitRepository repository = anExampleRepository();
+        final File existingRepoDirectory = new File(cloneDirectoryPath, REPOSITORY_PATH);
+        Git.init().setDirectory(existingRepoDirectory).call().close();
+
+        final Either<Throwable, Git> result = new GitService().clone(repository, cloneDirectoryPath);
+
+        assertThat(result.isLeft()).as("clone of an already-cloned repository returns a Left").isTrue();
+        assertThat(result.getLeft()).isInstanceOf(RepositoryAlreadyClonedException.class)
+                                    .hasMessageContaining(REPOSITORY_NAME)
+                                    .hasMessageContaining("already cloned");
+    }
+
+    @Test
+    void clone_directoryIsNotARepository_isNotTreatedAsAlreadyCloned() {
+        final GitService gitService = new GitService();
+        gitService.setCloneProtocol(GitCloneProtocol.HTTPS);
+        final GitRepository repository = anExampleRepository();
+        final File notARepositoryDirectory = new File(cloneDirectoryPath, REPOSITORY_PATH);
+        assertThat(notARepositoryDirectory.mkdirs()).as("the target directory exists but is not a git repository").isTrue();
+
+        final Either<Throwable, Git> result = gitService.clone(repository, cloneDirectoryPath);
+
+        assertThat(result.isLeft()).as("cloning into a non-repository directory still attempts (and fails) the clone").isTrue();
+        assertThat(result.getLeft()).isNotInstanceOf(RepositoryAlreadyClonedException.class);
+    }
+
+    private GitRepository anExampleRepository() {
+        return GitRepository.builder()
+                            .name(REPOSITORY_NAME)
+                            .path(REPOSITORY_PATH)
+                            .cloneUrlSsh(REPOSITORY_SSH_URL)
+                            .cloneUrlHttps(REPOSITORY_HTTPS_URL)
+                            .build();
     }
 
     private <T> Stream<T> flowableToStream(Flux<T> gits) {

--- a/src/test/java/devex/github/GithubClientWithTokenTest.java
+++ b/src/test/java/devex/github/GithubClientWithTokenTest.java
@@ -15,20 +15,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @MicronautTest
 class GithubClientWithTokenTest {
 
+    private static final String ORGANIZATION = "devex-cli-example";
+    private static final String USER = "miguelaferreira";
+
     @Inject
     private GithubClient client;
 
     @Test
     void getOrganization() {
-        final Optional<GithubOrganization> maybeOrg = client.getOrganization("devex-cli-example");
+        final Optional<GithubOrganization> maybeOrg = client.getOrganization(ORGANIZATION);
 
         assertThat(maybeOrg).isNotEmpty();
-        assertThat(maybeOrg.get().getName()).isEqualTo("devex-cli-example");
+        assertThat(maybeOrg.get().getName()).isEqualTo(ORGANIZATION);
     }
 
     @Test
     void getOrganizationRepositories() {
-        final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getOrganizationRepositories("devex-cli-example", 1);
+        final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getOrganizationRepositories(ORGANIZATION, 1);
 
         final Iterable<HttpResponse<List<GithubRepository>>> iterable = repositories.toIterable();
         assertThat(iterable).hasSize(1);
@@ -36,6 +39,27 @@ class GithubClientWithTokenTest {
         assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
         assertThat(response.getBody()).isNotEmpty();
         assertThat(response.getBody().get()).isNotEmpty()
-                                            .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase("devex-cli-example"));
+                                            .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase(ORGANIZATION));
+    }
+
+    @Test
+    void getUser() {
+        final Optional<GithubOrganization> maybeUser = client.getUser(USER);
+
+        assertThat(maybeUser).isNotEmpty();
+        assertThat(maybeUser.get().getName()).isEqualTo(USER);
+    }
+
+    @Test
+    void getUserRepositories() {
+        final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getUserRepositories(USER, 1);
+
+        final Iterable<HttpResponse<List<GithubRepository>>> iterable = repositories.toIterable();
+        assertThat(iterable).hasSize(1);
+        final HttpResponse<List<GithubRepository>> response = iterable.iterator().next();
+        assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().get()).isNotEmpty()
+                                            .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase(USER));
     }
 }

--- a/src/test/java/devex/github/GithubClientWithoutTokenTest.java
+++ b/src/test/java/devex/github/GithubClientWithoutTokenTest.java
@@ -20,16 +20,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 class GithubClientWithoutTokenTest {
 
+    private static final String ORGANIZATION = "devex-cli-example";
+    private static final String USER = "miguelaferreira";
+
     @Inject
     private GithubClient client;
 
     @Test
     void getOrganization() {
         try {
-            final Optional<GithubOrganization> maybeOrg = client.getOrganization("devex-cli-example");
+            final Optional<GithubOrganization> maybeOrg = client.getOrganization(ORGANIZATION);
 
             assertThat(maybeOrg).isNotEmpty();
-            assertThat(maybeOrg.get().getName()).isEqualTo("devex-cli-example");
+            assertThat(maybeOrg.get().getName()).isEqualTo(ORGANIZATION);
         } catch (HttpClientResponseException e) {
             GithubTestHelper.handleException(e);
         }
@@ -38,7 +41,7 @@ class GithubClientWithoutTokenTest {
     @Test
     void getOrganizationRepositories() {
         try {
-            final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getOrganizationRepositories("devex-cli-example", 1);
+            final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getOrganizationRepositories(ORGANIZATION, 1);
 
             final Iterable<HttpResponse<List<GithubRepository>>> iterable = repositories.toIterable();
             assertThat(iterable).hasSize(1);
@@ -46,7 +49,36 @@ class GithubClientWithoutTokenTest {
             assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
             assertThat(response.getBody()).isNotEmpty();
             assertThat(response.getBody().get()).isNotEmpty()
-                                                .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase("devex-cli-example"));
+                                                .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase(ORGANIZATION));
+        } catch (HttpClientResponseException e) {
+            GithubTestHelper.handleException(e);
+        }
+    }
+
+    @Test
+    void getUser() {
+        try {
+            final Optional<GithubOrganization> maybeUser = client.getUser(USER);
+
+            assertThat(maybeUser).isNotEmpty();
+            assertThat(maybeUser.get().getName()).isEqualTo(USER);
+        } catch (HttpClientResponseException e) {
+            GithubTestHelper.handleException(e);
+        }
+    }
+
+    @Test
+    void getUserRepositories() {
+        try {
+            final Flux<HttpResponse<List<GithubRepository>>> repositories = client.getUserRepositories(USER, 1);
+
+            final Iterable<HttpResponse<List<GithubRepository>>> iterable = repositories.toIterable();
+            assertThat(iterable).hasSize(1);
+            final HttpResponse<List<GithubRepository>> response = iterable.iterator().next();
+            assertThat(response.getStatus().getCode()).isEqualTo(HttpStatus.OK.getCode());
+            assertThat(response.getBody()).isNotEmpty();
+            assertThat(response.getBody().get()).isNotEmpty()
+                                                .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase(USER));
         } catch (HttpClientResponseException e) {
             GithubTestHelper.handleException(e);
         }

--- a/src/test/java/devex/github/GithubServiceTest.java
+++ b/src/test/java/devex/github/GithubServiceTest.java
@@ -3,6 +3,7 @@ package devex.github;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.vavr.control.Either;
 import reactor.core.publisher.Flux;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @MicronautTest
 class GithubServiceTest {
 
+    private static final String ORGANIZATION = "kubernetes";
+    private static final String USER = "miguelaferreira";
+
     @Inject
     private GithubService service;
 
@@ -22,10 +26,45 @@ class GithubServiceTest {
     )
     void getOrganizationRepositories() {
         try {
-            final Flux<GithubRepository> repositories = service.getOrganizationRepositories("kubernetes");
+            final Flux<GithubRepository> repositories = service.getOrganizationRepositories(ORGANIZATION);
 
             final Iterable<GithubRepository> iterable = repositories.toIterable();
             assertThat(iterable).hasSizeGreaterThan(50);
+        } catch (HttpClientResponseException e) {
+            GithubTestHelper.handleException(e);
+        }
+    }
+
+    @Test
+    void getUser() {
+        // No @Property to clear the token: getUser swallows HTTP errors into a Left,
+        // so an unauthenticated rate-limited response is indistinguishable from a real
+        // "not found". Running authenticated (when GITHUB_TOKEN is set) keeps it
+        // deterministic, while the guard below still tolerates a tokenless CI run.
+        final Either<String, GithubOrganization> maybeUser = service.getUser(USER);
+
+        // getUser wraps HTTP errors into a Left, so a rate-limited response surfaces
+        // here rather than as a thrown exception; skip the test in that case.
+        if (maybeUser.isLeft() && GithubTestHelper.isRateLimitExceeded(maybeUser.getLeft())) {
+            System.out.println(GithubTestHelper.RATE_LIMIT_SKIP_MESSAGE);
+            return;
+        }
+
+        assertThat(maybeUser.isRight()).as("user '%s' should be found", USER).isTrue();
+        assertThat(maybeUser.get().getName()).isEqualTo(USER);
+    }
+
+    @Test
+    @Property(
+            name = "github.token" // clear the property
+    )
+    void getUserRepositories() {
+        try {
+            final Flux<GithubRepository> repositories = service.getUserRepositories(USER);
+
+            final Iterable<GithubRepository> iterable = repositories.toIterable();
+            assertThat(iterable).isNotEmpty()
+                                .allSatisfy(repository -> assertThat(repository.getFullName()).containsIgnoringCase(USER));
         } catch (HttpClientResponseException e) {
             GithubTestHelper.handleException(e);
         }

--- a/src/test/java/devex/github/GithubTestHelper.java
+++ b/src/test/java/devex/github/GithubTestHelper.java
@@ -6,11 +6,18 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class GithubTestHelper {
 
+    static final String RATE_LIMIT_EXCEEDED_MESSAGE = "API rate limit exceeded";
+    static final String RATE_LIMIT_SKIP_MESSAGE = "Test skipped due to API rate limit exception";
+
     static void handleException(HttpClientResponseException e) {
-        if (e.getMessage().contains("API rate limit exceeded")) {
-            System.out.println("Test skipped due to API rate limit exception");
+        if (isRateLimitExceeded(e.getMessage())) {
+            System.out.println(RATE_LIMIT_SKIP_MESSAGE);
         } else {
             fail(e);
         }
+    }
+
+    static boolean isRateLimitExceeded(String message) {
+        return message != null && message.contains(RATE_LIMIT_EXCEEDED_MESSAGE);
     }
 }


### PR DESCRIPTION
This PR adds support for cloning GH user repos as if the user is an organization.

It also prints a info message saying a repository has already been cloned, instead of a warning for failed git operation.