### PR TITLE
Point release workflow at renamed brew formulas

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -172,8 +172,8 @@ jobs:
 
           echo "archive-sha=${archive_sha}" >> "$GITHUB_OUTPUT"
 
-          scripts/update-formula.sh "Formula/devex-cli.rb" "${new_version}" "${archive_sha}"
-          scripts/update-formula.sh "Formula/devex-cli-native-binary.rb" "${new_version}" "${all_files_sha}"
+          scripts/update-formula.sh "Formula/devex-cli-jdk.rb" "${new_version}" "${archive_sha}"
+          scripts/update-formula.sh "Formula/devex-cli.rb" "${new_version}" "${all_files_sha}"
         env:
           new_version: ${{ env.new_version }}
           all_files_sha: ${{ env.all_files_sha }}


### PR DESCRIPTION
The Homebrew tap renames its formulas (see miguelaferreira/homebrew-tools#17): the native-image formula becomes `devex-cli` and the JVM formula becomes `devex-cli-jdk`.

This updates the `Update formula native image` step in `create-release.yaml` so automated releases keep updating the correct files:

- source-archive sha → `Formula/devex-cli-jdk.rb` (JVM build)
- all-files sha → `Formula/devex-cli.rb` (native binaries)

Must merge together with miguelaferreira/homebrew-tools#17.